### PR TITLE
Keep scope torch/triton pins; restore Waypoint-1-Small; fix RGBA starter image

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,27 +21,24 @@ dev = [
 ]
 
 [tool.uv]
+# Keep the plugin's transitive resolution locked to daydream-scope's torch/triton
+# pins (2.9.1 / 3.5.1). world_engine on pin-torch-1.5 already pins the same, so
+# these overrides are belt-and-suspenders against any loose transitive (taehv,
+# gemlite, flashinfer) pulling a conflicting torch into scope's venv.
 override-dependencies = [
-    # world_engine 1.5 needs torch==2.10.0 / triton==3.6.0 — torch 2.9.1's
-    # inductor crashes on triton 3.6's kernel metadata (no `cluster_dims`,
-    # fixed upstream in pytorch/pytorch#167187, shipped in 2.10.0).
-    # daydream-scope 0.2.2 still pins 2.9.1 / triton 3.5.1; override both here.
-    "torch==2.10.0",
-    "torchvision==0.25.0",
-    "triton==3.6.0 ; sys_platform == 'linux'",
-    "triton-windows==3.6.0.post26 ; sys_platform == 'win32'",
+    "torch==2.9.1",
+    "torchvision==0.24.1",
+    "triton==3.5.1 ; sys_platform == 'linux'",
+    "triton-windows==3.5.1.post24 ; sys_platform == 'win32'",
 ]
 
 [tool.uv.sources]
 daydream-scope = { git = "https://github.com/daydreamlive/scope" }
-world-engine = { git = "https://github.com/Overworldai/world_engine", branch = "main" }
+world-engine = { git = "https://github.com/daydreamlive/world_engine", branch = "pin-torch-1.5" }
 torch = [
     { index = "pytorch-cu128", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 torchvision = [
-    { index = "pytorch-cu128", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
-]
-torchaudio = [
     { index = "pytorch-cu128", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 

--- a/src/scope_overworld/__init__.py
+++ b/src/scope_overworld/__init__.py
@@ -2,13 +2,18 @@
 
 import scope.core
 
-from .pipeline import Waypoint360Pipeline, WaypointPipeline
+from .pipeline import Waypoint1SmallPipeline, Waypoint360Pipeline, WaypointPipeline
 
 
 @scope.core.hookimpl
 def register_pipelines(register):
     register(WaypointPipeline)
     register(Waypoint360Pipeline)
+    register(Waypoint1SmallPipeline)
 
 
-__all__ = ["Waypoint360Pipeline", "WaypointPipeline"]
+__all__ = [
+    "Waypoint1SmallPipeline",
+    "Waypoint360Pipeline",
+    "WaypointPipeline",
+]

--- a/src/scope_overworld/pipeline.py
+++ b/src/scope_overworld/pipeline.py
@@ -1,7 +1,7 @@
 from typing import TYPE_CHECKING, ClassVar
 
 import torch
-from torchvision.io import read_image
+from torchvision.io import ImageReadMode, read_image
 from torchvision.transforms.v2.functional import resize as _tv_resize
 
 from scope.core.config import get_model_file_path
@@ -89,7 +89,9 @@ class WaypointPipeline(Pipeline):
             # center-crop the user's image to 16:9, resize to canvas, and
             # broadcast across the 4-frame temporal window to seed the stream.
             if images and len(images) > 0:
-                img = read_image(images[0])  # CHW uint8 at original aspect
+                # Force RGB (3 channels) — taehv1_5's VAE encoder asserts
+                # shape[-1] == 3, so any RGBA input would hard-crash.
+                img = read_image(images[0], mode=ImageReadMode.RGB)  # CHW uint8
                 _, h, w = img.shape
                 # Center-crop to 16:9
                 target = 16 / 9
@@ -196,7 +198,7 @@ class Waypoint1SmallPipeline(Pipeline):
             self.engine.reset()
 
         if images and len(images) > 0:
-            image = read_image(images[0])  # CHW uint8
+            image = read_image(images[0], mode=ImageReadMode.RGB)  # CHW uint8
             image = image.permute(1, 2, 0)  # HWC uint8
             self.engine.append_frame(image)
 

--- a/src/scope_overworld/pipeline.py
+++ b/src/scope_overworld/pipeline.py
@@ -10,7 +10,7 @@ from scope.core.pipelines.interface import Pipeline
 from world_engine import CtrlInput as WorldCtrlInput
 from world_engine import WorldEngine
 
-from .schema import Waypoint360Config, WaypointConfig
+from .schema import Waypoint1SmallConfig, Waypoint360Config, WaypointConfig
 
 if TYPE_CHECKING:
     from scope.core.pipelines.schema import BasePipelineConfig
@@ -126,3 +126,92 @@ class Waypoint360Pipeline(WaypointPipeline):
     @classmethod
     def get_config_class(cls) -> type["BasePipelineConfig"]:
         return Waypoint360Config
+
+
+class Waypoint1SmallPipeline(Pipeline):
+    """Waypoint 1 (Small) — the original Waypoint model with text-prompt
+    conditioning and an owl_vae autoencoder. Output is a single frame per call.
+    """
+
+    @classmethod
+    def get_config_class(cls) -> type["BasePipelineConfig"]:
+        return Waypoint1SmallConfig
+
+    def __init__(
+        self,
+        prompt: str = "A fun game",
+        n_frames: int = 4096,
+        device: torch.device | None = None,
+        dtype: torch.dtype = torch.bfloat16,
+        warmup_frames: int = 3,
+        **kwargs,
+    ):
+        self.device = (
+            device
+            if device is not None
+            else torch.device("cuda" if torch.cuda.is_available() else "cpu")
+        )
+        self.dtype = dtype
+
+        model_path = str(get_model_file_path("Waypoint-1-Small"))
+        ae_path = str(get_model_file_path("owl_vae_f16_c16_distill_v0_nogan"))
+        prompt_encoder_path = str(get_model_file_path("umt5-xl"))
+
+        # world_engine passes device straight into safetensors.load_file, whose
+        # Rust bindings accept only str/int (not torch.device). Pass a string.
+        self.engine = WorldEngine(
+            model_path,
+            model_config_overrides={
+                "n_frames": n_frames,
+                "ae_uri": ae_path,
+                "prompt_encoder_uri": prompt_encoder_path,
+            },
+            device=str(self.device),
+            dtype=self.dtype,
+        )
+        self.engine.set_prompt(prompt)
+        self._current_prompt: str | None = prompt
+
+        self._warmup(warmup_frames)
+
+    def _warmup(self, n_frames: int) -> None:
+        for _ in range(n_frames):
+            self.engine.gen_frame(ctrl=WorldCtrlInput())
+
+    def __call__(self, **kwargs) -> dict:
+        """Generate a frame with controller input.
+
+        Returns:
+            dict: {"video": tensor of shape (1, H, W, 3) in [0, 1]}.
+        """
+        manage_cache = kwargs.get("manage_cache", False)
+        init_cache = kwargs.get("init_cache", False)
+        images = kwargs.get("images")
+        prompts = kwargs.get("prompts")
+
+        if manage_cache and images and len(images) > 0:
+            init_cache = True
+
+        if init_cache:
+            self.engine.reset()
+
+        if images and len(images) > 0:
+            image = read_image(images[0])  # CHW uint8
+            image = image.permute(1, 2, 0)  # HWC uint8
+            self.engine.append_frame(image)
+
+        if prompts and len(prompts) > 0:
+            first_prompt = prompts[0]
+            new_prompt = (
+                first_prompt["text"] if isinstance(first_prompt, dict) else first_prompt
+            )
+            if new_prompt != self._current_prompt:
+                self.engine.set_prompt(new_prompt)
+                self._current_prompt = new_prompt
+
+        ctrl_input: CtrlInput = kwargs.get("ctrl_input") or CtrlInput()
+        win_keys = convert_to_win_keycodes(ctrl_input)
+        ctrl = WorldCtrlInput(button=win_keys, mouse=ctrl_input.mouse)
+
+        frame = self.engine.gen_frame(ctrl=ctrl)
+        return {"video": frame.unsqueeze(0).float() / 255.0}

--- a/src/scope_overworld/schema.py
+++ b/src/scope_overworld/schema.py
@@ -103,3 +103,60 @@ class Waypoint360Config(WaypointConfig):
 
     height: int = 360
     width: int = 640
+
+
+class Waypoint1SmallConfig(BasePipelineConfig):
+    """Configuration for Waypoint 1 (Small) pipeline — the original Waypoint
+    model, with text-prompt conditioning and an owl_vae autoencoder.
+    """
+
+    pipeline_id = "waypoint_1_small"
+    pipeline_name = "Waypoint 1 (Small)"
+    pipeline_description = (
+        "Streaming pipeline for the original Waypoint-1-Small autoregressive video world model (text prompts + controller)."
+    )
+    docs_url = "https://github.com/Overworldai/world_engine"
+
+    supports_prompts = True
+    default_temporal_interpolation_method = None
+    default_spatial_interpolation_method = None
+
+    supports_cache_management = True
+
+    modes = {"text": ModeDefaults(default=True)}
+
+    artifacts: ClassVar[list[Artifact]] = [
+        HuggingfaceRepoArtifact(
+            repo_id="Overworld/Waypoint-1-Small",
+            files=["model.safetensors", "config.yaml"],
+        ),
+        HuggingfaceRepoArtifact(
+            repo_id="OpenWorldLabs/owl_vae_f16_c16_distill_v0_nogan",
+            files=[
+                "encoder.safetensors",
+                "encoder_conf.yml",
+                "decoder.safetensors",
+                "decoder_conf.yml",
+            ],
+        ),
+        HuggingfaceRepoArtifact(
+            repo_id="google/umt5-xl",
+            files=[
+                "config.json",
+                "pytorch_model-00001-of-00002.bin",
+                "pytorch_model-00002-of-00002.bin",
+                "pytorch_model.bin.index.json",
+                "special_tokens_map.json",
+                "spiece.model",
+                "tokenizer.json",
+                "tokenizer_config.json",
+            ],
+        ),
+    ]
+
+    ctrl_input: CtrlInput | None = None
+
+    images: list[str] | None = Field(
+        default=None,
+        description="List of reference image paths for conditioning",
+    )


### PR DESCRIPTION
Stacked on #9. Three changes to the Waypoint-1.5 port so it drops into a stock `daydream-scope` venv without a torch/triton bump and keeps the original Waypoint-1 (Small) pipeline working.

## What changes

### 1. Stay on scope's torch/triton pins
- `pyproject.toml`: point `world-engine` at [`daydreamlive/world_engine@pin-torch-1.5`](https://github.com/daydreamlive/world_engine/tree/pin-torch-1.5). That branch is `Overworldai/world_engine` main with torch pinned back to `2.9.1` / triton back to `3.5.1`, matching daydream-scope's own pin set. Overrides reset to scope's pins; `flashinfer-python` kept Linux-only.
- No world_engine 1.5 code actually requires torch 2.10 or triton 3.6 APIs, the bump in the upstream pyproject was incidental. flash-attn / sage-attn wheels in scope are built against torch 2.9, so leaving torch on 2.9.1 preserves their ABI.

### 2. Restore Waypoint-1-Small alongside Waypoint-1.5
Adds a third pipeline (`waypoint_1_small`) with text-prompt conditioning and the `owl_vae` + `umt5-xl` artifact set, so the plugin covers both model generations instead of replacing 1.0 with 1.5. `WorldEngine` already gates the prompt encoder on `prompt_conditioning is not None` and the AE on `taehv_ae`, so one engine build serves both.

Registered pipelines after this PR:
- `waypoint`, Waypoint-1.5-1B (720p, 4-frame output, no prompts)
- `waypoint_360p`, Waypoint-1.5-1B-360P
- `waypoint_1_small`, Waypoint-1-Small (single-frame, text prompts)

### 3. Fix RGBA starter-image crash
`torchvision.io.read_image` returns whatever channel count the file has on disk. An RGBA PNG produces a 4-channel tensor which `taehv1_5`'s VAE encoder rejects with `Expected [4, H, W, 3] RGB uint8`. Passing `mode=ImageReadMode.RGB` drops the alpha channel at read time. Applied to both the 1.5 starter-image path and the 1-Small frame append.

## Companion change in world_engine

The `pin-torch-1.5` branch of `daydreamlive/world_engine` carries two commits over `Overworldai/world_engine` main:

1. `Align deps with daydream-scope pins`, the pin rewrite described above.
2. `Defer gemlite autotune warmup to first INT8 layer instance`, the existing `quantize.py` ran a multi-minute gemlite autotune at **module import** time, which fires whenever any pipeline in this plugin is loaded, even non-quantized ones. Moved into a lazy `_ensure_gemlite_initialized()` that runs from `INT8W8A8GemLite.__init__`, so only the `intw8a8` tier pays the cost. Behaviour is identical when `intw8a8` is selected.

## Test plan

- [x] Plugin installs cleanly into a stock daydream-scope venv (editable install), no torch/torchao/torchvision/triton churn
- [x] All three pipelines register: `waypoint`, `waypoint_360p`, `waypoint_1_small`
- [x] Non-quantized `waypoint` load does not trigger the gemlite warmup (thanks to companion commit in world_engine)
- [x] `waypoint` pipeline runs end-to-end with a starter image (verified on RTX 5090, Windows, CUDA 12.8)
- [x] RGBA starter image no longer crashes
- [x] `waypoint_360p` smoke test
- [x] `waypoint_1_small` smoke test (needs `Waypoint-1-Small` + `owl_vae` + `umt5-xl` artifacts)
- [ ] `intw8a8` / `fp8w8a8` quant tiers (gated gemlite path)
- [ ] `nvfp4` on Linux (requires flashinfer-python build)

## Scope-side note, not blocking

Plugin install via the `install_plugin` API fails on Windows with uv 0.11.7 + `--torch-backend cu128` + `torchao==0.15.0` in constraints.txt. uv 0.9.x resolves it fine. Workaround: install with `editable=True`, which bypasses the compile step. Worth a separate issue on `daydreamlive/scope`; out of scope for this PR.